### PR TITLE
Require webrick and rexml to fix Ruby 3 LoadError issues

### DIFF
--- a/capybara-webmock.gemspec
+++ b/capybara-webmock.gemspec
@@ -26,6 +26,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rack", ">= 1.4"
   spec.add_dependency "rack-proxy", ">= 0.6.0"
   spec.add_dependency "selenium-webdriver", "~> 3.0"
+  spec.add_dependency "rexml", ">= 3.2"
+  spec.add_dependency "webrick", ">= 1.7"
 
   spec.add_development_dependency "bundler", ">= 1.13"
   spec.add_development_dependency "pry", "~> 0.10.4"


### PR DESCRIPTION
Fixes for Ruby 3.

The errors in capybara-webmock stop our capybara process from starting because we're using capybara-webmock to proxy through, 
and capybara-webmock on Ruby 3 wasn't working.

The issues are just that webrick is no longer a bundled gem in Ruby 3,
and rexml is now a bundled gem but still needs requiring:
https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/
For a description of default vs bundled gems see: https://github.com/janlelis/stdgems



Example error:
```
LoadError Exception: cannot load such file -- webrick
```


---

Upstream PR:
https://github.com/hashrocket/capybara-webmock/pull/39