### PR TITLE
Run tests with GitHub actions to ensure gem works with more versions of Ruby

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,0 @@
-version: 2
-jobs:
-  build:
-    docker:
-      - image: circleci/ruby:2.5.1-browsers
-    steps:
-      - checkout
-      - run: bundle install
-      - run: rake

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,20 @@
+name: Run tests
+
+on: [push]
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
+        ruby: [2.5, 2.6, 2.7, '3.0', head]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - run: bundle exec rake

--- a/lib/capybara/webmock.rb
+++ b/lib/capybara/webmock.rb
@@ -70,6 +70,8 @@ module Capybara
       def chrome_options
         ::Selenium::WebDriver::Chrome::Options.new.tap do |options|
           options.add_argument "--proxy-server=127.0.0.1:#{port_number}"
+          options.add_argument('--headless')
+          options.add_argument('--disable-gpu')
         end
       end
 


### PR DESCRIPTION
### Changes

- Run on all major Ruby versions (and head) to ensure gem works with these versions.

- Add --disable-gpu and --headless options for compatibility on the GitHub
Actions ubuntu runner. Otherwise the chrome instance crashes on startup, because
it does not have an X server.

---

Upstream PR:
https://github.com/hashrocket/capybara-webmock/pull/38